### PR TITLE
Revert "Bump python from 3.8-slim-bullseye to 3.10.1-slim-bullseye"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.1-slim-bullseye as base
+FROM python:3.8-slim-bullseye as base
 
 # Setup env
 ENV LANG C.UTF-8


### PR DESCRIPTION
Reverts matchd-ch/matchd-backend#57