### PR TITLE
Html emails - Correct spelling mistake for company name in email footer

### DIFF
--- a/db/templates/db/email/base/footer/default.html
+++ b/db/templates/db/email/base/footer/default.html
@@ -4,7 +4,7 @@
   <td class="main-footer">
     Der Schutz deiner Daten ist uns wichtig. Mit der Angabe deiner Email-Adresse akzeptierst du die
     <a href="{{ data_protection_url }}" target="_blank">Datenschutzerklärung</a> des
-    Vereins IT St.Gallen (&#60;IT&#62; rockt), dem Anbieter von Matchd.
+    Vereins IT St.Gallen (&#60;IT&#62;rockt!), dem Anbieter von Matchd.
   </td>
 </tr>
 </tbody>


### PR DESCRIPTION
Related to [slack msg](https://joshmartin.slack.com/archives/C02FPJ4V6J2/p1653899335534469)